### PR TITLE
Decrease tests boilerplate

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -31,16 +31,31 @@ class Request
         return $this;
     }
 
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
     public function path(string $path): self
     {
         $this->path = $path;
         return $this;
     }
 
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
     public function queryParams(array $queryParams): self
     {
         $this->queryParams = $queryParams;
         return $this;
+    }
+
+    public function getQueryParams(): array
+    {
+        return $this->queryParams;
     }
 
     /**
@@ -50,6 +65,14 @@ class Request
     {
         $this->body = $body;
         return $this;
+    }
+
+    /**
+     * @return array|\Psr\Http\Message\StreamInterface|string
+     */
+    public function getBody()
+    {
+        return $this->body;
     }
 
     public function pagination(int $skip, int $limit): self

--- a/tests/Resources/CustomersTest.php
+++ b/tests/Resources/CustomersTest.php
@@ -2,136 +2,75 @@
 
 namespace Tests\Resources;
 
+use OpenPix\PhpSdk\Request;
 use OpenPix\PhpSdk\RequestTransport;
 use OpenPix\PhpSdk\Resources\Customers;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Message\StreamInterface;
 
 final class CustomersTest extends TestCase
 {
     public function testList(): void
     {
         $requestTransportMock = $this->createMock(RequestTransport::class);
-        $requestFactoryMock = $this->createMock(RequestFactoryInterface::class);
-        $streamFactoryMock = $this->createMock(StreamFactoryInterface::class);
-
-        $requestFactoryMock->expects($this->once())
-            ->method("createRequest")
-            ->with("GET", $this->stringContains("https://example.com/customer"));
 
         $customers = new Customers($requestTransportMock);
 
-        $customers->list()->getPagedRequest()->build("https://example.com", $requestFactoryMock, $streamFactoryMock);
+        $pagedRequest = $customers->list()->getPagedRequest();
+
+        $this->assertSame($pagedRequest->getPath(), "/customer");
+        $this->assertSame($pagedRequest->getMethod(), "GET");
+        $this->assertSame($pagedRequest->getBody(), null);
     }
 
     public function testGetOne()
     {
-        $requestFactoryMock = $this->createMock(RequestFactoryInterface::class);
-        $streamFactoryMock = $this->createMock(StreamFactoryInterface::class);
-        $httpClientMock = $this->createMock(ClientInterface::class);
-        $requestMock = $this->createMock(RequestInterface::class);
-        $responseMock = $this->createMock(ResponseInterface::class);
-        $streamMock = $this->createMock(StreamInterface::class);
-
-        $requestTransport = new RequestTransport(
-            "app id",
-            $httpClientMock,
-            $requestFactoryMock,
-            $streamFactoryMock,
-        );
-
         $correlationID = "fe7834b4060c488a9b0f89811be5f5cf";
+        $customer = [
+            "customer" => [
+                "name" => "John Doe",
+            ],
+        ];
 
-        $requestFactoryMock->expects($this->once())
-            ->method("createRequest")
-            ->with("GET", "https://api.woovi.com/api/v1/customer/" . $correlationID)
-            ->willReturn($requestMock);
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) use ($correlationID, $customer) {
+                $this->assertSame("GET", $request->getMethod());
+                $this->assertSame("/customer/" . $correlationID, $request->getPath());
+                $this->assertSame($request->getBody(), null);
+                $this->assertSame($request->getQueryParams(), []);
 
-        $requestMock->expects($this->exactly(2))
-            ->method("withAddedHeader")
-            ->willReturnSelf();
+                return $customer;
+            });
 
-        $httpClientMock->expects($this->once())
-            ->method("sendRequest")
-            ->with($requestMock)
-            ->willReturn($responseMock);
-
-        $responseMock->expects($this->once())
-            ->method("getBody")
-            ->willReturn($streamMock);
-
-        $streamMock->expects($this->once())
-            ->method("getContents")
-            ->willReturn(json_encode(["customer" => []]));
-
-        $customers = new Customers($requestTransport);
+        $customers = new Customers($requestTransportMock);
 
         $result = $customers->getOne($correlationID);
 
-        $this->assertSame($result, ["customer" => []]);
+        $this->assertSame($result, $customer);
     }
 
     public function testCreate()
     {
-        $requestFactoryMock = $this->createMock(RequestFactoryInterface::class);
-        $streamFactoryMock = $this->createMock(StreamFactoryInterface::class);
-        $httpClientMock = $this->createMock(ClientInterface::class);
-        $requestMock = $this->createMock(RequestInterface::class);
-        $requestStreamMock = $this->createMock(StreamInterface::class);
-        $responseMock = $this->createMock(ResponseInterface::class);
-        $responseStreamMock = $this->createMock(StreamInterface::class);
-
-        $requestTransport = new RequestTransport(
-            "app id",
-            $httpClientMock,
-            $requestFactoryMock,
-            $streamFactoryMock,
-        );
-
         $customer = [
             "customer" => [
                 "name" => "John Doe"
             ],
         ];
 
-        $requestFactoryMock->expects($this->once())
-            ->method("createRequest")
-            ->with("POST", "https://api.woovi.com/api/v1/customer")
-            ->willReturn($requestMock);
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) use ($customer) {
+                $this->assertSame("POST", $request->getMethod());
+                $this->assertSame("/customer", $request->getPath());
+                $this->assertSame($request->getBody(), $customer);
+                $this->assertSame($request->getQueryParams(), []);
 
-        $requestMock->expects($this->exactly(3))
-            ->method("withAddedHeader")
-            ->willReturnSelf();
+                return $customer;
+            });
 
-        $streamFactoryMock->expects($this->once())
-            ->method("createStream")
-            ->with(json_encode($customer))
-            ->willReturn($requestStreamMock);
-
-        $requestMock->expects($this->once())
-            ->method("withBody")
-            ->with($requestStreamMock)
-            ->willReturnSelf();
-
-        $httpClientMock->expects($this->once())
-            ->method("sendRequest")
-            ->with($requestMock)
-            ->willReturn($responseMock);
-
-        $responseMock->expects($this->once())
-            ->method("getBody")
-            ->willReturn($responseStreamMock);
-
-        $responseStreamMock->expects($this->once())
-            ->method("getContents")
-            ->willReturn(json_encode($customer));
-
-        $customers = new Customers($requestTransport);
+        $customers = new Customers($requestTransportMock);
 
         $result = $customers->create($customer);
 


### PR DESCRIPTION
Mocking dependencies has been reduced due to the addition of getters in `Request` objects, allowing you to make assertions about request data (path, method, query parameters and body) without the need to make assertions about PSR-7 requests generated from objects `Request`.