### PR TITLE
Pagination improvements

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -67,71 +67,55 @@ class Paginator implements Iterator
     }
 
     /**
-     * Get current result.
+     * Retrieve current result.
      *
      * @return array<mixed>
      */
     public function current(): array
     {
-        if (is_null($this->lastResult)) return $this->update();
-
-        return $this->lastResult;
+        return $this->lastResult = $this->requestTransport->transport($this->getPagedRequest());
     }
 
     /**
-     * Go to first page and update the current result.
+     * Go to first page.
      */
     public function rewind(): void
     {
-        $this->skip = 0;
-        $this->update();
+        $this->skip(0);
     }
 
     /**
-     * Go to next page and update the current result.
+     * Go to next page.
      */
     public function next(): void
     {
-        $this->skip += $this->perPage;
-        $this->update();
+        $this->skip($this->skip + $this->perPage);
     }
 
     /**
-     * Go to previous page and update the current result.
+     * Go to previous page.
      */
     public function previous(): void
     {
-        $this->skip -= $this->perPage;
-        $this->update();
+        $this->skip($this->skip - $this->perPage);
     }
 
     /**
-     * Changes the current page and update the current result.
+     * Changes the current page.
      */
     public function go(int $page): void
     {
-        $this->skip = $page * $this->perPage;
-        $this->update();
+        $this->skip($page * $this->perPage);
     }
 
     /**
-     * Returns true if it is possible to change to another page besides the current one.
+     * Returns true if has next page.
      */
     public function valid(): bool
     {
-        $pagination = $this->getPagination();
+        if (is_null($this->lastResult)) return true;
 
-        return $pagination["hasPreviousPage"] || $pagination["hasNextPage"];
-    }
-
-    /**
-     * Update current pagination result.
-     *
-     * @return array<mixed>
-     */
-    public function update(): array
-    {
-        return $this->lastResult = $this->requestTransport->transport($this->getPagedRequest());
+        return $this->getPagination()["hasNextPage"];
     }
 
     /**
@@ -156,7 +140,7 @@ class Paginator implements Iterator
      */
     private function getPagination(): array
     {
-        $lastResult = $this->lastResult ?? $this->update();
+        $lastResult = $this->lastResult ?? $this->current();
 
         if (empty($lastResult["pageInfo"])) {
             throw new TypeError("Endpoint does not support pagination.");

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -50,12 +50,28 @@ class Paginator implements Iterator
     }
 
     /**
+     * Get maxium amount of resources per page.
+     */
+    public function getPerPageCount(): int
+    {
+        return $this->perPage;
+    }
+
+    /**
      * Skips an amount of resources.
      */
     public function skip(int $skip): self
     {
         $this->skip = $skip;
         return $this;
+    }
+
+    /**
+     * Get amount of resources skipped.
+     */
+    public function getSkippedCount(): int
+    {
+        return $this->skip;
     }
 
     /**

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -11,56 +11,93 @@ final class PaginatorTest extends TestCase
 {
     public function testGetPagedRequest(): void
     {
-        $requestTransportMock = $this->createMock(RequestTransport::class);
         $listRequestMock = $this->createMock(Request::class);
-
         $listRequestMock->expects($this->once())
             ->method("pagination")
             ->with(20, 30);
 
-        $paginator = new Paginator($requestTransportMock, $listRequestMock);
+        $paginator = new Paginator($this->createMock(RequestTransport::class), $listRequestMock);
 
-        $paginator->perPage(30)
-            ->skip(20)
-            ->getPagedRequest();
+        $paginator->perPage(30)->skip(20)->getPagedRequest();
     }
 
-    public function testSendRequest(): void
+    public function testUpdate(): void
     {
-        $requestTransportMock = $this->createMock(RequestTransport::class);
-        $listRequestStub = $this->createStub(Request::class);
-
-        $paginator = new Paginator($requestTransportMock, $listRequestStub);
-
-        $requestTransportMock->expects($this->once())
-            ->method("transport")
-            ->with($paginator->getPagedRequest());
-
-        $paginator->sendRequest();
+        $this->getPaginatorForUpdateTests()->update();
     }
 
     public function testNext(): void
     {
-        $this->getPaginatorForNavigationTests(170, 50)
-            ->perPage(50)
-            ->skip(120)
-            ->next();
+        $this->getPaginatorForUpdateTests(30)->next();
     }
 
     public function testPrevious(): void
     {
-        $this->getPaginatorForNavigationTests(120, 50)
-            ->perPage(50)
-            ->skip(170)
-            ->previous();
+        $this->getPaginatorForUpdateTests(0, 30, 30)->previous();
     }
 
     public function testGo(): void
     {
-        $this->getPaginatorForNavigationTests()
-            ->perPage(50)
-            ->skip(0)
-            ->go(1);
+        $this->getPaginatorForUpdateTests(30)->go(1);
+    }
+
+    public function testRewind(): void
+    {
+        $this->getPaginatorForUpdateTests(0, 30, 30)->rewind();
+    }
+
+    public function testKey(): void
+    {
+        $paginator = new Paginator($this->createMock(RequestTransport::class), $this->createMock(Request::class));
+
+        $paginator->perPage(30)->skip(50);
+
+        $this->assertSame(1, $paginator->key());
+    }
+
+    public function testCurrent(): void
+    {
+        $paginator = $this->getPaginatorForUpdateTests();
+
+        $paginator->current();
+
+        // Should not send request if there is already a previous result
+        // It will fail if it sends more than one request to the request transport
+        $paginator->current();
+    }
+
+    public function testValid(): void
+    {
+        $makePaginator = fn ($hasPreviousPage, $hasNextPage) => new Paginator(
+            $this->createMock(RequestTransport::class),
+            $this->createMock(Request::class),
+            [
+                "pageInfo" => [
+                    "hasPreviousPage" => $hasPreviousPage,
+                    "hasNextPage" => $hasNextPage,
+                ],
+            ]
+        );
+
+        $this->assertTrue($makePaginator(true, true)->valid());
+        $this->assertTrue($makePaginator(true, false)->valid());
+        $this->assertTrue($makePaginator(false, true)->valid());
+        $this->assertFalse($makePaginator(false, false)->valid());
+    }
+
+    public function testGetTotalResourcesCount(): void
+    {
+        $paginator = new Paginator(
+            $this->createMock(RequestTransport::class),
+            $this->createMock(Request::class),
+            [
+                "pageInfo" => [
+                    "totalCount" => 10,
+                ],
+            ]
+        );
+
+        $this->assertSame(10, $paginator->getTotalResourcesCount());
     }
 
     /**
@@ -69,22 +106,21 @@ final class PaginatorTest extends TestCase
      *
      * Must run the method under test when you get the paginator (the "Act" of AAA).
      */
-    private function getPaginatorForNavigationTests(int $expectedSkip = 50, int $expectedLimit = 50): Paginator
+    private function getPaginatorForUpdateTests(int $expectedSkip = 0, int $expectedLimit = 30, int $skip = 0, int $perPage = 30): Paginator
     {
-        $requestTransportMock = $this->createMock(RequestTransport::class);
         $listRequestMock = $this->createMock(Request::class);
-
-        $requestTransportMock->expects($this->once())
-            ->method("transport")
-            ->with($listRequestMock);
-
         $listRequestMock->expects($this->once())
             ->method("pagination")
             ->with($expectedSkip, $expectedLimit)
             ->willReturn($listRequestMock);
 
-        $paginator = new Paginator($requestTransportMock, $listRequestMock);
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->with($listRequestMock);
 
-        return $paginator;
+        return (new Paginator($requestTransportMock, $listRequestMock))
+            ->skip($skip)
+            ->perPage($perPage);
     }
 }


### PR DESCRIPTION
This PR adds improvements to the `Paginator`.

He is now an [`Iterator`](https://www.php.net/manual/en/class.iterator.php), currently having the following methods:
- `current` to get the response of the current page.
- `next`/`previous`/`go`/`rewind` to change the underlying `skip` parameter.
- `key` (from `Iterator` interface) to get the current page number.
- `valid` (from `Iterator` interface) to check whether it is possible to move the `Paginator` forward or backward.
- `getPagedRequest` to return HTTP `Request`.
- `getTotalResourcesCount` to return the total amount of resources.
- `skip` and `getSkippedCount` / `perPage` and `getPerPageCount` to manipulate request pagination parameters.

As an iterator, it can be used in a `foreach`:
```php
use OpenPix\PhpSdk\Client;

$client = Client::create("YOUR APP ID", "BASE URI");

$paginator = $client->customers()->list();

// Note: If, for example, there are 5000 clients in the API, all of them will be returned at once if there is no break in the loop.
// Maybe add a configurable maximum amount of resources that can be returned?
foreach ($paginator as $page) {
    foreach ($page["customers"] as $customer) {
        echo "Customer name: " . $customer["name"] . "\n";
    }
}
```

Also directly:
```php
$paginator = $client->customers()->list();

// Note: Same issue as `foreach`
do {
    $currentPage = $paginator->current(); // This send a HTTP request

    foreach ($currentPage["customers"] as $customer) {
        echo "Customer name: " . $customer["name"] . "\n";
    }

    $paginator->next();
} while ($paginator->valid());
```

## How this works in a forEach
When starting the loop, the instruction calls the `rewind` method to reset the `Paginator`. This allows reuse of the same `Paginator` in different loops.

After that, `valid` is called to check if the `Paginator` is valid to continue the iteration. If `false`, stops the iteration.

If `true`, the `current` method is called to request a page from the server and returns the page.

After that, the `next` method is called to change the current page to the next one. This method does not send HTTP requests.

After that, we return to the `valid` method, executing it as above, until it returns `false`.

For more information, see [Iterator](https://www.php.net/manual/en/class.iterator.php).