### PR TITLE
Add customization on charges qrcode image links

### DIFF
--- a/src/RequestTransport.php
+++ b/src/RequestTransport.php
@@ -94,6 +94,14 @@ class RequestTransport
     }
 
     /**
+     * Get base URI of API.
+     */
+    public function getBaseUri(): string
+    {
+        return $this->baseUri;
+    }
+
+    /**
      * Add default headers like Authorization and `platform`.
      */
     private function withRequestDefaultParameters(RequestInterface $request): RequestInterface

--- a/src/Resources/Charges.php
+++ b/src/Resources/Charges.php
@@ -18,6 +18,8 @@ class Charges
 
     /**
      * Create a new Charges instance.
+     *
+     * @param RequestTransport $requestTransport Used to send HTTP requests.
      */
     public function __construct(RequestTransport $requestTransport)
     {
@@ -168,6 +170,6 @@ class Charges
      */
     public function getQrCodeImageLink(string $paymentLinkID, int $size = 1024): string
     {
-        return "https://api.woovi.com/openpix/charge/brcode/image/" . $paymentLinkID . ".png?size=" . $size;
+        return $this->requestTransport->getBaseUri() . "/openpix/charge/brcode/image/" . $paymentLinkID . ".png?size=" . $size;
     }
 }

--- a/tests/Resources/ChargesTest.php
+++ b/tests/Resources/ChargesTest.php
@@ -92,10 +92,12 @@ final class ChargesTest extends TestCase
 
     public function testGetQrCodeImageLink(): void
     {
-        $charges = new Charges($this->createMock(RequestTransport::class));
+        $charges = new Charges($this->createConfiguredMock(RequestTransport::class, [
+            "getBaseUri" => "https://example.com",
+        ]));
 
         $result = $charges->getQrCodeImageLink("123456", 256);
 
-        $this->assertSame("https://api.woovi.com/openpix/charge/brcode/image/123456.png?size=256", $result);
+        $this->assertSame("https://example.com/openpix/charge/brcode/image/123456.png?size=256", $result);
     }
 }


### PR DESCRIPTION
This allows changing the link from Woovi to OpenPix in the `getQrCodeImageLink` method.

It is currently returning a hard-coded link from Woovi.