### PR TITLE
Throw ApiErrorException with returned error array

### DIFF
--- a/src/RequestTransport.php
+++ b/src/RequestTransport.php
@@ -118,7 +118,13 @@ class RequestTransport
         }
 
         if (!empty($contents["error"])) {
-            throw new ApiErrorException($contents["error"]);
+            $error = $contents["error"];
+
+            if (is_array($error)) {
+                $error = $error["message"];
+            }
+
+            throw new ApiErrorException($error);
         }
 
         return $contents;


### PR DESCRIPTION
The API currently may return an object of type `{error: string}` or `{error: { message: string }}` (for example, when removing a charge that does not exist). This PR adds support for the last case, which was causing bugs in previous versions.