### PR TITLE
feat(webhooks): add webhook validation method

### DIFF
--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -12,6 +12,11 @@ use OpenPix\PhpSdk\RequestTransport;
 class Webhooks
 {
     /**
+     * Used for webhook signature validation.
+     */
+    private const VALIDATION_PUBLIC_KEY_BASE64 = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FDLytOdElranpldnZxRCtJM01NdjNiTFhEdApwdnhCalk0QnNSclNkY2EzcnRBd01jUllZdnhTbmQ3amFnVkxwY3RNaU94UU84aWVVQ0tMU1dIcHNNQWpPL3paCldNS2Jxb0c4TU5waS91M2ZwNnp6MG1jSENPU3FZc1BVVUcxOWJ1VzhiaXM1WloySVpnQk9iV1NwVHZKMGNuajYKSEtCQUE4MkpsbitsR3dTMU13SURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=";
+
+    /**
      * Request transport used to send HTTP requests.
      */
     private RequestTransport $requestTransport;
@@ -132,5 +137,38 @@ class Webhooks
             ->body($webhook);
 
         return $this->requestTransport->transport($request);
+    }
+
+    /**
+     * Validate webhook signature.
+     *
+     * Every Webhook request has the header `x-webhook-signature` which is the signature
+     * generated with Woovi's secret key and the Webhook payload. Upon receiving the
+     * header, you can validate whether the signature is valid using this method and
+     * continue the Webhook flow.
+     *
+     * ## Usage
+     * ```php
+     * $payload = file_get_contents("php://input");
+     * $signature = getallheaders()["x-webhook-signature"];
+     *
+     * $client->webhooks()->isWebhookValid($payload, $signature);
+     * ```
+     *
+     * @link https://developers.openpix.com.br/docs/webhook/webhook-signature-validation
+     *
+     * @param string $payload Webhook payload string encoded in JSON. You can get this using `file_get_contents("php://input")`, for example.
+     * @param string $signature `x-webhook-signature` HTTP header sent by OpenPix request. You can get this using the `getallheaders` function, for example.
+     *
+     * @return bool Returns `true` if the received webhook is valid and `false` otherwise.
+     */
+    public function isWebhookValid(string $payload, string $signature): bool
+    {
+        return openssl_verify(
+            $payload,
+            base64_decode($signature),
+            base64_decode(self::VALIDATION_PUBLIC_KEY_BASE64),
+            "sha256WithRSAEncryption"
+        );
     }
 }

--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -169,6 +169,6 @@ class Webhooks
             base64_decode($signature),
             base64_decode(self::VALIDATION_PUBLIC_KEY_BASE64),
             "sha256WithRSAEncryption"
-        );
+        ) === 1;
     }
 }

--- a/tests/Resources/WebhooksTest.php
+++ b/tests/Resources/WebhooksTest.php
@@ -72,4 +72,48 @@ final class WebhooksTest extends TestCase
 
         $this->assertSame(["webhook" => []], $result);
     }
+
+    public function testIsWebhookValidReturnsTrueWithValidWebhook(): void
+    {
+        $webhooks = new Webhooks($this->createStub(RequestTransport::class));
+
+        $this->assertTrue(
+            $webhooks->isWebhookValid(
+                $this->getWebhookPayloadFixture(),
+                $this->getWebhookSignatureFixture()
+            )
+        );
+    }
+
+    public function testIsWebhookValidReturnsFalseWithInvalidSignature(): void
+    {
+        $webhooks = new Webhooks($this->createStub(RequestTransport::class));
+
+        $this->assertFalse($webhooks->isWebhookValid($this->getWebhookPayloadFixture(), "invalid-signature"));
+    }
+
+    public function testIsWebhookValidReturnsFalseWithInvalidPayload(): void
+    {
+        $webhooks = new Webhooks($this->createStub(RequestTransport::class));
+
+        $this->assertFalse($webhooks->isWebhookValid("invalid-payload", $this->getWebhookSignatureFixture()));
+    }
+
+    /**
+     * @link https://developers.openpix.com.br/docs/webhook/webhook-signature-validation
+     */
+    private function getWebhookPayloadFixture(): string
+    {
+        return <<<JSON
+        { "pixQrCode": null, "charge": { "status": "COMPLETED", "customer": { "name": "Antonio Victor", "taxID": { "taxID": "12345678976", "type": "BR:CPF" }, "email": "antoniocliente@example.com", "correlationID": "4979ceba-2132-4292-bd90-bee7fb2125e4" }, "value": 1000, "comment": "Pagamento OpenPix", "transactionID": "ea83401ed4834b3ea6f1f283b389af29", "correlationID": "417bae21-3d08-4cdb-9c2d-fee63c89e9e4", "paymentLinkID": "34697ed2-3790-4b60-8512-e7465b142d84", "createdAt": "2021-03-12T12:43:54.528Z", "updatedAt": "2021-03-12T12:44:09.360Z", "brCode": "https://api.openpix.com.br/openpix/openpix/testing?transactionID=ea83401ed4834b3ea6f1f283b389af29" }, "pix": { "charge": { "status": "COMPLETED", "customer": { "name": "Antonio Victor", "taxID": { "taxID": "12345678976", "type": "BR:CPF" }, "email": "antoniocliente@example.com", "correlationID": "4979ceba-2132-4292-bd90-bee7fb2125e4" }, "value": 1000, "comment": "Pagamento OpenPix", "transactionID": "ea83401ed4834b3ea6f1f283b389af29", "correlationID": "417bae21-3d08-4cdb-9c2d-fee63c89e9e4", "paymentLinkID": "34697ed2-3790-4b60-8512-e7465b142d84", "createdAt": "2021-03-12T12:43:54.528Z", "updatedAt": "2021-03-12T12:44:09.360Z" }, "customer": { "correlationID": "9134e286-6f71-427a-bf00-241681624586", "email": "email1@example.com", "name": "Loma", "phone": "+5511999999999", "taxID": { "taxID": "47043622050", "type": "BR:CPF" } }, "payer": { "correlationID": "9134e286-6f71-427a-bf00-241681624586", "email": "email1@example.com", "name": "Loma", "phone": "+5511999999999", "taxID": { "taxID": "47043622050", "type": "BR:CPF" } }, "time": "2021-03-12T12:44:09.269Z", "value": 1, "transactionID": "ea83401ed4834b3ea6f1f283b389af29", "infoPagador": "OpenPix testing" }, "company": { "id": "624f46f9e93f9f521c8308d7", "name": "Pizzaria do José", "taxID": "4722767300014" }, "account": { "clientId": "ZOJ64B9B-ZM1W-89MI-4UCI-OP2LVIU6NY75" } }
+        JSON;
+    }
+
+    /**
+     * @link https://developers.openpix.com.br/docs/webhook/webhook-signature-validation
+     */
+    private function getWebhookSignatureFixture(): string
+    {
+        return "lL2nnXgmLFGgxJ8+jCDguqouU4ucrIxYJcU5SPrJFaNcJajTJHYVldqc/z4YFIjAjtPEALe699WosgPY08W7CLpidvtm06Qwa4YMB0l/DcTS93O91NdSH/adjugEKiOb76Zj/0jB8mqOmWCFYbweOBa17bssuEkd5Lw7Q5L314Y=";
+    }
 }


### PR DESCRIPTION
This PR addresses #33.

`isWebhookValid` method has been added to the `Webhooks` resource:
 ```php
// Basic usage:

 $payload = file_get_contents("php://input");
 $signature = getallheaders()["x-webhook-signature"];
 
 $client->webhooks()->isWebhookValid($payload, $signature);
 ```