### PR TITLE
ci: send coverage to codecov

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,12 +26,20 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          coverage: xdebug
 
       - name: Dependencies installation
         run: composer update --no-interaction --prefer-dist
 
       - name: Run PHPUnit
         run: composer test
+
+     - name: Upload to Codecov
+       uses: codecov/codecov-action@v2
+       with:
+         token: ${{ secrets.CODE_COV_TOKEN }}
+         files: ./coverage.xml
+         verbose: true
 
   lint-and-fix:
     name: Lint code and fix code style

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/coverage.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,5 +21,8 @@
         <include>
             <directory suffix=".php">src/</directory>
         </include>
+        <report>
+            <clover outputFile="./coverage.xml" />
+        </report>
     </coverage>
 </phpunit>


### PR DESCRIPTION
waiting for [codecov app](https://github.com/apps/codecov) approval on php-sdk repo only:
![image](https://github.com/Open-Pix/php-sdk/assets/96352451/c108b3f9-c03f-41d4-845f-b93dccc468c1)
This PR closes #40.