### PR TITLE
fix(php): add support for php 7.3

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-version: [7.4, 8.0, 8.1, 8.2]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
 
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 7.3
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "php-http/discovery": "^1.18",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -23,7 +23,10 @@ class Client
 
     public const BASE_URI = "https://api.openpix.com.br";
 
-    private RequestTransport $requestTransport;
+    /**
+     * @var RequestTransport
+     */
+    private $requestTransport;
 
     /**
      * Create a new client from an application ID and base URI (by default is OpenPix).

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -34,30 +34,38 @@ class Paginator implements Iterator
 {
     /**
      * Transport used by HTTP requests.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Last request sent to API.
+     * 
+     * @var Request
      */
-    private Request $listRequest;
+    private $listRequest;
 
     /**
      * Last result from API.
      *
      * @var array<mixed>|null
      */
-    private ?array $lastResult;
+    private $lastResult;
 
     /**
      * Amount of resources to be skipped.
+     * 
+     * @var int
      */
-    private int $skip = 0;
+    private $skip = 0;
 
     /**
      * Amount of resources per page.
+     * 
+     * @var int
      */
-    private int $perPage = 30;
+    private $perPage = 30;
 
     /**
      * Create a new `Paginator` instance.

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -34,14 +34,14 @@ class Paginator implements Iterator
 {
     /**
      * Transport used by HTTP requests.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;
 
     /**
      * Last request sent to API.
-     * 
+     *
      * @var Request
      */
     private $listRequest;
@@ -55,14 +55,14 @@ class Paginator implements Iterator
 
     /**
      * Amount of resources to be skipped.
-     * 
+     *
      * @var int
      */
     private $skip = 0;
 
     /**
      * Amount of resources per page.
-     * 
+     *
      * @var int
      */
     private $perPage = 30;

--- a/src/Request.php
+++ b/src/Request.php
@@ -14,20 +14,24 @@ class Request
 {
     /**
      * The path to endpoint.
+     * 
+     * @var string
      */
-    private string $path;
+    private $path;
 
     /**
      * The HTTP method of endpoint.
+     * 
+     * @var string
      */
-    private string $method;
+    private $method;
 
     /**
      * Query parameters to set into URI on request build.
      *
      * @var array<mixed>
      */
-    private array $queryParams = [];
+    private $queryParams = [];
 
     /**
      * Body of request.

--- a/src/Request.php
+++ b/src/Request.php
@@ -14,14 +14,14 @@ class Request
 {
     /**
      * The path to endpoint.
-     * 
+     *
      * @var string
      */
     private $path;
 
     /**
      * The HTTP method of endpoint.
-     * 
+     *
      * @var string
      */
     private $method;

--- a/src/RequestTransport.php
+++ b/src/RequestTransport.php
@@ -24,35 +24,35 @@ class RequestTransport
 
     /**
      * Underlying HTTP client.
-     * 
+     *
      * @var ClientInterface
      */
     private $httpClient;
 
     /**
      * Request factory passed to API `Request` builder.
-     * 
+     *
      * @var RequestFactoryInterface
      */
     private $requestFactory;
 
     /**
      * Stream factory passed to API `Request` builder.
-     * 
+     *
      * @var StreamFactoryInterface
      */
     private $streamFactory;
 
     /**
      * Application ID.
-     * 
+     *
      * @var string
      */
     private $appId;
 
     /**
      * Base URI of all requests handled by RequestTransport.
-     * 
+     *
      * @var string
      */
     private $baseUri;

--- a/src/RequestTransport.php
+++ b/src/RequestTransport.php
@@ -24,28 +24,38 @@ class RequestTransport
 
     /**
      * Underlying HTTP client.
+     * 
+     * @var ClientInterface
      */
-    private ClientInterface $httpClient;
+    private $httpClient;
 
     /**
      * Request factory passed to API `Request` builder.
+     * 
+     * @var RequestFactoryInterface
      */
-    private RequestFactoryInterface $requestFactory;
+    private $requestFactory;
 
     /**
      * Stream factory passed to API `Request` builder.
+     * 
+     * @var StreamFactoryInterface
      */
-    private StreamFactoryInterface $streamFactory;
+    private $streamFactory;
 
     /**
      * Application ID.
+     * 
+     * @var string
      */
-    private string $appId;
+    private $appId;
 
     /**
      * Base URI of all requests handled by RequestTransport.
+     * 
+     * @var string
      */
-    private string $baseUri;
+    private $baseUri;
 
     /**
      * Create a new RequestTransport instance.

--- a/src/Resources/Charges.php
+++ b/src/Resources/Charges.php
@@ -13,7 +13,7 @@ class Charges
 {
     /**
      * The transport used by {@see Request}.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Charges.php
+++ b/src/Resources/Charges.php
@@ -13,8 +13,10 @@ class Charges
 {
     /**
      * The transport used by {@see Request}.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Charges instance.

--- a/src/Resources/Customers.php
+++ b/src/Resources/Customers.php
@@ -15,8 +15,10 @@ class Customers
 {
     /**
      * Used to send HTTP requests to customers API.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Customers instance.

--- a/src/Resources/Customers.php
+++ b/src/Resources/Customers.php
@@ -15,7 +15,7 @@ class Customers
 {
     /**
      * Used to send HTTP requests to customers API.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Payments.php
+++ b/src/Resources/Payments.php
@@ -15,7 +15,7 @@ class Payments
 {
     /**
      * Used to send HTTP requests to the payments API.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Payments.php
+++ b/src/Resources/Payments.php
@@ -15,8 +15,10 @@ class Payments
 {
     /**
      * Used to send HTTP requests to the payments API.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Payments instance.

--- a/src/Resources/Refunds.php
+++ b/src/Resources/Refunds.php
@@ -15,7 +15,7 @@ class Refunds
 {
     /**
      * Transport used to send HTTP requests.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Refunds.php
+++ b/src/Resources/Refunds.php
@@ -15,8 +15,10 @@ class Refunds
 {
     /**
      * Transport used to send HTTP requests.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Refunds instance.

--- a/src/Resources/Refunds.php
+++ b/src/Resources/Refunds.php
@@ -113,7 +113,7 @@ class Refunds
      *      "value" => 0,
      *      // Your transaction ID, or endToEnd ID, to keep track of this refund.
      *      "transactionEndToEndId" => "",
-     *      // Your correlation ID, unique identifier refund
+     *      // Your correlation ID, unique identifier refund.
      *      "correlationID" => "",
      *      // Comment of this refund. Maximum length of 140 characters.
      *      "comment" => "",

--- a/src/Resources/Subscriptions.php
+++ b/src/Resources/Subscriptions.php
@@ -12,7 +12,7 @@ class Subscriptions
 {
     /**
      * Used to send HTTP requests.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Subscriptions.php
+++ b/src/Resources/Subscriptions.php
@@ -12,8 +12,10 @@ class Subscriptions
 {
     /**
      * Used to send HTTP requests.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Subscriptions instance.

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -15,7 +15,7 @@ class Transactions
 {
     /**
      * Used to send HTTP requests to transactions API.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Transactions.php
+++ b/src/Resources/Transactions.php
@@ -15,8 +15,10 @@ class Transactions
 {
     /**
      * Used to send HTTP requests to transactions API.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Transactions instance.

--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -18,7 +18,7 @@ class Webhooks
 
     /**
      * Request transport used to send HTTP requests.
-     * 
+     *
      * @var RequestTransport
      */
     private $requestTransport;

--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -18,8 +18,10 @@ class Webhooks
 
     /**
      * Request transport used to send HTTP requests.
+     * 
+     * @var RequestTransport
      */
-    private RequestTransport $requestTransport;
+    private $requestTransport;
 
     /**
      * Create a new Webhooks instance.

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -24,7 +24,9 @@ final class PaginatorTest extends TestCase
     public function testNext(): void
     {
         $this->testPaginatorNavigation(
-            fn (Paginator $paginator) => $paginator->next(),
+            function (Paginator $paginator): void {
+                $paginator->next();
+            },
             30
         );
     }
@@ -32,7 +34,9 @@ final class PaginatorTest extends TestCase
     public function testPrevious(): void
     {
         $this->testPaginatorNavigation(
-            fn (Paginator $paginator) => $paginator->previous(),
+            function (Paginator $paginator): void {
+                $paginator->previous();
+            },
             0,
             30
         );
@@ -41,14 +45,20 @@ final class PaginatorTest extends TestCase
     public function testGo(): void
     {
         $this->testPaginatorNavigation(
-            fn (Paginator $paginator) => $paginator->go(2),
+            function (Paginator $paginator): void {
+                $paginator->go(2);
+            },
             60
         );
     }
 
     public function testRewind(): void
     {
-        $this->testPaginatorNavigation(fn (Paginator $paginator) => $paginator->rewind());
+        $this->testPaginatorNavigation(
+            function (Paginator $paginator): void {
+                $paginator->rewind();
+            }
+        );
     }
 
     public function testKey(): void


### PR DESCRIPTION
- Remove typed properties in favor of phpdocs.
- Remove arrow functions in favor of normal anonymous functions.
- Use PHP 7.3 on jobs of code quality workflow.
- Add support for PHP 7.3 on Composer manifest.